### PR TITLE
fix: update script commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "url": "git@github.com:ChainSafe/web3-circle-libs.git"
   },
   "scripts": {
-    "lint": "yarn workspace web3-circle-sdk lint",
-    "build": "yarn workspace web3-circle-sdk build",
-    "build:docs": "yarn workspace web3-circle-sdk build:docs",
-    "test": "yarn workspace web3-circle-sdk test"
+    "lint": "yarn workspace circle-demo-webapp lint",
+    "build": "yarn workspace circle-demo-webapp build",
+    "dev": "yarn workspace circle-demo-webapp dev",
+    "test": "yarn workspace web3-circle-sdk test",
+    "start": "yarn workspace circle-demo-webapp start"
   },
   "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
This PR updates the script commands in package root to point to circle-demo-app  and replaces/removes web3-circle-sdk scripts as were no longer using that