### PR TITLE
fix: tree shaking web3 icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@circle-fin/developer-controlled-wallets": "^7.0.0",
-    "@web3icons/react": "^3.16.0",
     "lucide-react": "^0.474.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/circle-demo-webapp/package.json
+++ b/packages/circle-demo-webapp/package.json
@@ -36,7 +36,6 @@
     "@remix-run/node": "^2.15.0",
     "@remix-run/react": "^2.15.0",
     "@remix-run/serve": "^2.15.0",
-    "@web3icons/react": "^3.16.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "ethereum-blockies-base64": "^1.0.2",

--- a/packages/circle-react-elements/README.md
+++ b/packages/circle-react-elements/README.md
@@ -59,7 +59,6 @@ This package requires the following peer dependencies:
 ```json
 {
   "@circle-fin/developer-controlled-wallets": "^7.0.0", // Circle SDK
-  "@web3icons/react": "^3.16.0", // Blockchain icons
   "lucide-react": "^0.474.0", // Icon library
   "react": "^18.2.0",
   "react-dom": "^18.2.0",
@@ -71,13 +70,13 @@ This package requires the following peer dependencies:
 Install them all in a single command:
 
 ```bash
-npm install @circle-fin/developer-controlled-wallets @web3icons/react lucide-react react react-dom react-hook-form tailwindcss
+npm install @circle-fin/developer-controlled-wallets lucide-react react react-dom react-hook-form tailwindcss
 ```
 
 or
 
 ```bash
-yarn add @circle-fin/developer-controlled-wallets @web3icons/react lucide-react react react-dom react-hook-form tailwindcss
+yarn add @circle-fin/developer-controlled-wallets lucide-react react react-dom react-hook-form tailwindcss
 ```
 
 ## Tailwind CSS Setup

--- a/packages/circle-react-elements/package.json
+++ b/packages/circle-react-elements/package.json
@@ -54,6 +54,7 @@
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slot": "^1.1.0",
+    "@web3icons/react": "^4.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "ethereum-blockies-base64": "^1.0.2",
@@ -94,7 +95,6 @@
   },
   "peerDependencies": {
     "@circle-fin/developer-controlled-wallets": "^7.0.0",
-    "@web3icons/react": "^3.16.0",
     "lucide-react": "^0.474.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/circle-react-elements/src/GettingStarted.mdx
+++ b/packages/circle-react-elements/src/GettingStarted.mdx
@@ -59,7 +59,6 @@ This package requires the following peer dependencies:
 ```json
 {
   "@circle-fin/developer-controlled-wallets": "^7.0.0", // Circle SDK
-  "@web3icons/react": "^3.16.0", // Blockchain icons
   "lucide-react": "^0.474.0", // Icon library
   "react": "^18.2.0",
   "react-dom": "^18.2.0",
@@ -71,13 +70,13 @@ This package requires the following peer dependencies:
 Install them all in a single command:
 
 ```bash
-npm install @circle-fin/developer-controlled-wallets @web3icons/react lucide-react react react-dom react-hook-form tailwindcss
+npm install @circle-fin/developer-controlled-wallets lucide-react react react-dom react-hook-form tailwindcss
 ```
 
 or
 
 ```bash
-yarn add @circle-fin/developer-controlled-wallets @web3icons/react lucide-react react react-dom react-hook-form tailwindcss
+yarn add @circle-fin/developer-controlled-wallets lucide-react react react-dom react-hook-form tailwindcss
 ```
 
 ## Tailwind CSS Setup

--- a/packages/circle-react-elements/src/components/ChainIcon/ChainIcon.tsx
+++ b/packages/circle-react-elements/src/components/ChainIcon/ChainIcon.tsx
@@ -1,10 +1,19 @@
 import type { Blockchain } from '@circle-fin/developer-controlled-wallets';
-import { NetworkIcon } from '@web3icons/react';
+import {
+  NetworkArbitrumOne,
+  NetworkPolygon,
+  NetworkNearProtocol,
+  NetworkAvalanche,
+  NetworkSolana,
+  NetworkEthereum,
+  NetworkUnichain,
+  type IconComponentProps,
+} from '@web3icons/react';
 
 /**
  * Props for the ChainIcon component
  */
-export interface ChainIconProps {
+export interface ChainIconProps extends IconComponentProps {
   /**
    * The blockchain network to display an icon for
    * Supports all networks from Circle's API including testnet variants
@@ -12,38 +21,37 @@ export interface ChainIconProps {
   blockchain: Blockchain;
 }
 
-/**
- * Mapping of Circle blockchain identifiers to web3icons network names
- */
-const BlockchainToIconMap: Record<Blockchain, string> = {
-  'ARB-SEPOLIA': 'arbitrum',
-  ARB: 'arbitrum',
-  'AVAX-FUJI': 'avalanche',
-  AVAX: 'avalanche',
-  'ETH-SEPOLIA': 'ethereum',
-  ETH: 'ethereum',
-  'EVM-TESTNET': '',
-  EVM: '',
-  'MATIC-AMOY': 'polygon',
-  MATIC: 'polygon',
-  'NEAR-TESTNET': 'near-protocol',
-  NEAR: 'near-protocol',
-  'SOL-DEVNET': 'solana',
-  SOL: 'solana',
-  'UNI-SEPOLIA': 'uni',
-};
+const BlockchainToIconMap: Record<Blockchain, React.ComponentType<IconComponentProps>> = {
+  'ARB-SEPOLIA': NetworkArbitrumOne,
+  ARB: NetworkArbitrumOne,
+  'AVAX-FUJI': NetworkAvalanche,
+  AVAX: NetworkAvalanche,
+  'ETH-SEPOLIA': NetworkEthereum,
+  ETH: NetworkEthereum,
+  'EVM-TESTNET': NetworkEthereum,
+  EVM: NetworkEthereum,
+  'MATIC-AMOY': NetworkPolygon,
+  MATIC: NetworkPolygon,
+  'NEAR-TESTNET': NetworkNearProtocol,
+  NEAR: NetworkNearProtocol,
+  'SOL-DEVNET': NetworkSolana,
+  SOL: NetworkSolana,
+  'UNI-SEPOLIA': NetworkUnichain,
+} as const;
 
 /**
  * Displays a branded icon for a given blockchain network
  *
  * Features:
- * - Shows branded network icons using web3icons library
+ * - Uses specific network icons from @web3icons/react
  * - Supports all Circle-supported networks including testnets
- * - Consistent 20px size for all icons
- * - Uses official branded network colors
  */
-export function ChainIcon({ blockchain }: ChainIconProps) {
-  return (
-    <NetworkIcon network={BlockchainToIconMap[blockchain]} size={20} variant="branded" />
-  );
+export function ChainIcon({ blockchain, ...props }: ChainIconProps) {
+  const Icon = BlockchainToIconMap[blockchain];
+
+  if (!Icon) {
+    return null;
+  }
+
+  return <Icon size={20} variant="branded" {...props} />;
 }

--- a/packages/circle-react-elements/src/components/LazyTokenIcon/LazyTokenIcon.tsx
+++ b/packages/circle-react-elements/src/components/LazyTokenIcon/LazyTokenIcon.tsx
@@ -1,0 +1,20 @@
+import type { TokenIconProps } from '@web3icons/react';
+import { lazy, Suspense } from 'react';
+
+const TokenIcon = lazy(() =>
+  import('@web3icons/react').then((mod) => ({
+    default: mod.TokenIcon,
+  })),
+);
+
+export type LazyTokenIconProps = TokenIconProps & {
+  ref?: React.Ref<SVGSVGElement>;
+};
+
+export function LazyTokenIcon(props: LazyTokenIconProps) {
+  return (
+    <Suspense fallback={<div className="w-10 h-10 bg-muted rounded-full" />}>
+      <TokenIcon {...props} />
+    </Suspense>
+  );
+}

--- a/packages/circle-react-elements/src/components/LazyTokenIcon/index.ts
+++ b/packages/circle-react-elements/src/components/LazyTokenIcon/index.ts
@@ -1,0 +1,1 @@
+export * from './LazyTokenIcon';

--- a/packages/circle-react-elements/src/components/TokenItem/TokenItem.tsx
+++ b/packages/circle-react-elements/src/components/TokenItem/TokenItem.tsx
@@ -1,5 +1,6 @@
 import type { Token } from '@circle-fin/developer-controlled-wallets';
-import { TokenIcon } from '@web3icons/react';
+
+import { LazyTokenIcon } from '../LazyTokenIcon';
 
 /**
  * Props for the TokenItem component
@@ -17,14 +18,11 @@ export interface TokenItemProps {
  *
  * Features:
  * - Shows branded token icons using web3icons library
- * - Handles split token symbols (e.g., "USDC-ETH" displays USDC icon)
- * - Consistent styling with muted text and icon alignment
- * - Fixed icon size of 24px for visual consistency
  */
 export function TokenItem({ token }: TokenItemProps) {
   return (
     <div className="flex items-center space-x-2">
-      <TokenIcon
+      <LazyTokenIcon
         symbol={token?.symbol?.split('-')[0] ?? ''}
         size={24}
         variant="branded"

--- a/packages/circle-react-elements/src/components/TokenSelect/TokenSelectItem.tsx
+++ b/packages/circle-react-elements/src/components/TokenSelect/TokenSelectItem.tsx
@@ -1,5 +1,6 @@
 import { Balance } from '@circle-fin/developer-controlled-wallets';
-import { TokenIcon } from '@web3icons/react';
+
+import { LazyTokenIcon } from '../LazyTokenIcon';
 
 /**
  * Props for the TokenSelectItem component
@@ -18,14 +19,11 @@ export interface TokenSelectItemProps {
  * Features:
  * - Shows branded token icon using web3icons library
  * - Displays token amount and symbol
- * - Handles split token symbols (e.g., "USDC-ETH" displays USDC icon)
- * - Fixed icon size of 24px for visual consistency
- * - Consistent styling with muted text and icon alignment
  */
 export function TokenSelectItem({ balance }: TokenSelectItemProps) {
   return (
     <div className="flex items-center space-x-2 pr-4">
-      <TokenIcon
+      <LazyTokenIcon
         symbol={balance.token.symbol?.split('-')[0] ?? ''}
         size={24}
         variant="branded"

--- a/packages/circle-react-elements/src/components/WalletBalance/WalletBalance.tsx
+++ b/packages/circle-react-elements/src/components/WalletBalance/WalletBalance.tsx
@@ -1,7 +1,7 @@
 import type { Balance } from '@circle-fin/developer-controlled-wallets';
-import { TokenIcon } from '@web3icons/react';
 
 import { Amount } from '~/components/Amount';
+import { LazyTokenIcon } from '~/components/LazyTokenIcon';
 
 /**
  * Props for the WalletBalance component
@@ -21,18 +21,12 @@ export interface WalletBalanceProps {
  * - Shows branded token icon using web3icons library
  * - Displays token name and symbol
  * - Shows formatted balance amount using Amount component
- * - Handles split token symbols (e.g., "USDC-ETH" displays USDC icon)
- * - Large 40px icon size for better visibility
- * - Responsive layout with space between token info and amount
- * - Consistent text styles with design system:
- *   - Medium weight for token name
- *   - Muted color for token symbol
  */
 export function WalletBalance({ balance }: WalletBalanceProps) {
   return (
     <div className="flex items-center justify-between space-x-8">
       <div className="flex items-center space-x-2">
-        <TokenIcon
+        <LazyTokenIcon
           symbol={balance.token.symbol?.split('-')[0] ?? ''}
           size={40}
           variant="branded"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2498,17 +2498,17 @@
   resolved "https://registry.yarnpkg.com/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz#6b69dc2a32a5b207ba43e556c25cc136a56659c4"
   integrity sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==
 
-"@web3icons/common@0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@web3icons/common/-/common-0.10.0.tgz#63f50e65d8fe2ecc30a831d7294740d984be9c25"
-  integrity sha512-Ksh9CAkxNtj9FPiBCNoctqj8ieS7eBcixtm4+Xt0ralK/35MltSrNizMYfrwXAlF9M3ACqRBkZbrHnIEPsrdLg==
+"@web3icons/common@0.11.6":
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/@web3icons/common/-/common-0.11.6.tgz#ce26c2b4152cd6dd2a42fafe4fc9d4bead08ef52"
+  integrity sha512-3Y+ImXPbn3f4x0EiEiqBjbzExmDgY2N05cHSRCzC9iLQwYVAFmHHGg+C1jWiM0PzKR2vq4A4ZwMTYQTSS0CJxA==
 
-"@web3icons/react@^3.16.0":
-  version "3.16.0"
-  resolved "https://registry.yarnpkg.com/@web3icons/react/-/react-3.16.0.tgz#9d4a9b17571838a49f8d960575473015392d0858"
-  integrity sha512-EDTKJA0Q9aR6ihiwaMZrJjwC/N0fteJd3doV2wOYm6/LiRQaWAZYbL9pUE0dVuuukSQC1MDL8lSU/qGZJ8ewJg==
+"@web3icons/react@^4.0.0":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@web3icons/react/-/react-4.0.7.tgz#3cd0df7b90102ba9703aec1648860e64753df2c2"
+  integrity sha512-Jz20iAr+fwEMkxKQbjq8N/6jvPVzY96QM4E47hDKOsIGsOHOybXA8BybCH59EZIe88yAQ1TYt5xnn0+qNJnsjQ==
   dependencies:
-    "@web3icons/common" "0.10.0"
+    "@web3icons/common" "0.11.6"
     react "^18.2.0"
 
 "@zxing/text-encoding@0.9.0":


### PR DESCRIPTION
It still loads 2K+ chunks in dev mode, but in production mode (demo build + start), everything looks fine.

@avkos, if you approve this, please merge and deploy so we can verify if the issue is resolved